### PR TITLE
one watcher

### DIFF
--- a/tail.go
+++ b/tail.go
@@ -5,16 +5,17 @@ package tail
 import (
 	"bufio"
 	"fmt"
-	"github.com/ActiveState/tail/ratelimiter"
-	"github.com/ActiveState/tail/util"
-	"github.com/ActiveState/tail/watch"
-	"gopkg.in/tomb.v1"
 	"io"
 	"io/ioutil"
 	"log"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/ActiveState/tail/ratelimiter"
+	"github.com/ActiveState/tail/util"
+	"github.com/ActiveState/tail/watch"
+	"gopkg.in/tomb.v1"
 )
 
 var (

--- a/tail_test.go
+++ b/tail_test.go
@@ -6,14 +6,15 @@
 package tail
 
 import (
-	"./watch"
 	_ "fmt"
-	"github.com/ActiveState/tail/ratelimiter"
 	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
 	"time"
+
+	"./watch"
+	"github.com/ActiveState/tail/ratelimiter"
 )
 
 func init() {

--- a/tail_test.go
+++ b/tail_test.go
@@ -41,7 +41,7 @@ func TestMustExist(t *testing.T) {
 		t.Error("MustExist:true on an existing file is violated")
 	}
 	tail.Stop()
-	Cleanup()
+	tail.Cleanup()
 }
 
 func TestStop(t *testing.T) {
@@ -52,7 +52,7 @@ func TestStop(t *testing.T) {
 	if tail.Stop() != nil {
 		t.Error("Should be stoped successfully")
 	}
-	Cleanup()
+	tail.Cleanup()
 }
 
 func MaxLineSizeT(_t *testing.T, follow bool, fileContent string, expected []string) {
@@ -66,7 +66,7 @@ func MaxLineSizeT(_t *testing.T, follow bool, fileContent string, expected []str
 	<-time.After(100 * time.Millisecond)
 	t.RemoveFile("test.txt")
 	tail.Stop()
-	Cleanup()
+	tail.Cleanup()
 }
 
 func TestMaxLineSizeFollow(_t *testing.T) {
@@ -90,7 +90,7 @@ func TestOver4096ByteLine(_t *testing.T) {
 	<-time.After(100 * time.Millisecond)
 	t.RemoveFile("test.txt")
 	tail.Stop()
-	Cleanup()
+	tail.Cleanup()
 }
 func TestOver4096ByteLineWithSetMaxLineSize(_t *testing.T) {
 	t := NewTailTest("Over4096ByteLineMaxLineSize", _t)
@@ -104,7 +104,7 @@ func TestOver4096ByteLineWithSetMaxLineSize(_t *testing.T) {
 	<-time.After(100 * time.Millisecond)
 	t.RemoveFile("test.txt")
 	// tail.Stop()
-	Cleanup()
+	tail.Cleanup()
 }
 
 func TestLocationFull(_t *testing.T) {
@@ -118,7 +118,7 @@ func TestLocationFull(_t *testing.T) {
 	<-time.After(100 * time.Millisecond)
 	t.RemoveFile("test.txt")
 	tail.Stop()
-	Cleanup()
+	tail.Cleanup()
 }
 
 func TestLocationFullDontFollow(_t *testing.T) {
@@ -133,7 +133,7 @@ func TestLocationFullDontFollow(_t *testing.T) {
 	<-time.After(100 * time.Millisecond)
 
 	tail.Stop()
-	Cleanup()
+	tail.Cleanup()
 }
 
 func TestLocationEnd(_t *testing.T) {
@@ -150,7 +150,7 @@ func TestLocationEnd(_t *testing.T) {
 	<-time.After(100 * time.Millisecond)
 	t.RemoveFile("test.txt")
 	tail.Stop()
-	Cleanup()
+	tail.Cleanup()
 }
 
 func TestLocationMiddle(_t *testing.T) {
@@ -168,7 +168,7 @@ func TestLocationMiddle(_t *testing.T) {
 	<-time.After(100 * time.Millisecond)
 	t.RemoveFile("test.txt")
 	tail.Stop()
-	Cleanup()
+	tail.Cleanup()
 }
 
 func _TestReOpen(_t *testing.T, poll bool) {
@@ -211,7 +211,7 @@ func _TestReOpen(_t *testing.T, poll bool) {
 	// the reading of data written above. Timings can vary based on
 	// test environment.
 	// tail.Stop()
-	Cleanup()
+	tail.Cleanup()
 }
 
 // The use of polling file watcher could affect file rotation
@@ -254,7 +254,7 @@ func _TestReSeek(_t *testing.T, poll bool) {
 	// the reading of data written above. Timings can vary based on
 	// test environment.
 	// tail.Stop()
-	Cleanup()
+	tail.Cleanup()
 }
 
 // The use of polling file watcher could affect file rotation
@@ -294,7 +294,7 @@ func TestRateLimiting(_t *testing.T) {
 	t.RemoveFile("test.txt")
 
 	// tail.Stop()
-	Cleanup()
+	tail.Cleanup()
 }
 
 func TestTell(_t *testing.T) {
@@ -328,7 +328,7 @@ func TestTell(_t *testing.T) {
 	}
 	t.RemoveFile("test.txt")
 	tail.Done()
-	Cleanup()
+	tail.Cleanup()
 }
 
 // Test library

--- a/watch/inotify.go
+++ b/watch/inotify.go
@@ -12,8 +12,6 @@ import (
 	"gopkg.in/tomb.v1"
 )
 
-var inotifyTracker *InotifyTracker
-
 // InotifyFileWatcher uses inotify to monitor file changes.
 type InotifyFileWatcher struct {
 	Filename string


### PR DESCRIPTION
This patch makes the library use a single file watcher for all operations. 