### PR TITLE
Workaround travis failures around gopkg.in imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,6 @@ script:
 
 go:
   - 1.2.1
+
+install:
+  - go get gopkg.in/fsnotify.v0

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ script:
   - go test -v ./...
 
 go:
-  - 1.2.1
+  - 1.3.3
+  - 1.4.2
 
 install:
   - go get gopkg.in/fsnotify.v0


### PR DESCRIPTION
By manually installing it.